### PR TITLE
Remove date microseconds below 7.1

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -97,13 +97,6 @@ class Date extends \DateTime
 		date_default_timezone_set('UTC');
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
-		// If php version below 7.1 and current time, add the microseconds to date.
-		// See https://secure.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
-		if ($date === 'now' && version_compare(PHP_VERSION, '7.1.0', '<'))
-		{
-			$date = parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u');
-		}
-
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);
 


### PR DESCRIPTION
Pull Request for New Issue

### Summary of Changes

This was removed in the CMS because of timezone issues.
It should removed here too.

### Testing Instructions

Code review.

### Documentation Changes Required

None.
Should be removed in 2.0 too